### PR TITLE
docs: correct documentation vs source behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 
 ---
 
+> **Full documentation:** [github.com/Quadstronaut/QuadClicker/wiki](https://github.com/Quadstronaut/QuadClicker/wiki) — Installation, CLI Reference, hotkey notes, troubleshooting, and building from source. This README is the quickstart and status overview; the wiki is the canonical deep reference.
+
 ## Overview
 
-QuadClicker is the definitive open-source auto-clicker: fully configurable, scriptable via CLI, accessibility-first, and distributed everywhere. Built as a monorepo with three separate **native** applications — no cross-platform frameworks, ever.
+QuadClicker is a fast, native, open-source auto-clicker: fully configurable, scriptable via CLI, and built as a monorepo with three separate **native** applications — no cross-platform frameworks, ever.
 
 | Platform | Language | Framework | Min OS |
 |---|---|---|---|
@@ -124,7 +126,7 @@ sudo cmake --install build
 
 ## CLI Reference
 
-When any argument other than `--minimized` is passed, the app runs headless with no GUI.
+When any argument other than `--minimized`, `--no-update-check`, or `--post-update` is passed, the app runs headless with no GUI. See the [wiki CLI Reference](https://github.com/Quadstronaut/QuadClicker/wiki/CLI-Reference) for the full flag table and examples.
 
 ```
 quadclicker [OPTIONS]
@@ -140,7 +142,9 @@ quadclicker [OPTIONS]
 | `--stop-after-seconds <n>` | float | 0 (unlimited) | Stop after N seconds |
 | `--idle-wait <n>` | float | 0 (disabled) | Wait for N seconds of idle before starting |
 | `--no-gui` | flag | auto | Force headless mode |
-| `--minimized` | flag | off | Launch GUI minimized to tray |
+| `--minimized` | flag | off | Launch GUI minimized to tray (GUI-compatible — does not trigger CLI mode) |
+| `--no-update-check` | flag | off | Skip the launch-time update check; GUI-compatible (Windows only) |
+| `--check-update` | flag | — | Check for update, print result, exit 0 (Windows only) |
 | `--version` | flag | — | Print version and exit 0 |
 | `--help` | flag | — | Print usage and exit 0 |
 
@@ -220,7 +224,7 @@ Settings are persisted automatically on exit and loaded on launch. JSON format i
 ### Known limitations
 
 - The mode-based **Click Rate** redesign and the **Taneth** palette are now in all three platforms' source. Linux is verified end-to-end; macOS source has them but remains unbuilt pending an Xcode-equipped machine.
-- Linux global hotkeys: `XGrabKey` (X11) is used; Wayland support is limited to compositors that expose `org.kde.kglobalaccel` (KDE) — GNOME Wayland users will not get global hotkeys until a compositor-side API exists.
+- Linux global hotkeys: `XGrabKey` (X11) is used. Under Wayland, hotkeys are **not supported** — the `HotkeyManager` detects the Wayland platform at startup and disables itself entirely. Use the Start/Stop button or the system tray instead. A compositor-side D-Bus shortcut API is a future milestone.
 
 ---
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,22 +1,39 @@
 # QuadClicker — macOS
 
-**Status: Phase 2 — Not yet started.**
+**Status: Phase 2 — Code-complete, UNVERIFIED.** All Swift source files are written and present in this directory, but the app has never been compiled or run — an Xcode-equipped Mac is required. The `build-macos.yml` CI workflow is a no-op placeholder and produces no artifact. No signed or notarized binary has been released.
 
-## Planned Stack
+## Stack
 
 | | |
 |---|---|
 | Language | Swift |
 | Framework | SwiftUI |
 | Input injection | `CGEventPost` (CoreGraphics) |
+| Settings persistence | `~/Library/Application Support/QuadClicker/settings.json` |
 | Menu bar | `NSStatusItem` (AppKit) |
-| Hotkeys | `CGEventTap` / `NSEvent.addGlobalMonitorForEvents` |
+| Hotkeys | `NSEvent.addGlobalMonitorForEvents` — requires Accessibility permission |
+| Idle detection | `CGEventSourceSecondsSinceLastEventType` |
 | Min OS | macOS 13 Ventura |
 
-## Phase 2 Deliverables
+## Building
+
+Requires Xcode 15+ on macOS 13+. See `CODE_SIGNING.md` for signing and notarization requirements.
+
+```bash
+open macos/QuadClicker.xcodeproj
+
+# Command-line build
+xcodebuild -project macos/QuadClicker.xcodeproj \
+           -scheme QuadClicker \
+           -configuration Release \
+           -derivedDataPath artifacts/macos
+
+# Run tests
+xcodebuild test -project macos/QuadClicker.xcodeproj \
+                -scheme QuadClickerTests \
+                -destination 'platform=macOS'
+```
+
+> **Note:** `CGEventPost` and global hotkeys require Accessibility permission. The app prompts on first launch when hotkeys are configured. Code signing and notarization are required for distribution — see `CODE_SIGNING.md`.
 
 See `PLAN.md § Phase 2` in the repo root for full specification.
-
-Requires:
-- Apple Developer account (for notarization) — see `CODE_SIGNING.md`
-- Xcode 15+ on macOS 13+


### PR DESCRIPTION
Source-verified documentation corrections from the wiki program:

- Settings persist on exit (not on change) - verified vs MainWindow OnClosed
- Wayland hotkeys: NOT supported, no KDE fallback - corrected false kglobalaccel claim (verified vs HotkeyManager.cpp)
- CLI table: added --no-update-check / --check-update (Windows-only)
- macos/README: corrected "Not yet started" to code-complete, UNVERIFIED, with real stack table
- README points to the wiki as canonical deep reference
- Softened unsupported marketing claims

Council verdicts: wiki council (1 opus + 2 sonnets) unanimous APPROVE after 3 fix rounds.
Wiki shipped at https://github.com/Quadstronaut/QuadClicker/wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)
